### PR TITLE
Restarting docker or rebooting or sometimes breaks Apache and Daphne

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -44,6 +44,12 @@ done
 
 echo_status "Starting up..."
 
+# Remove stale pid and lock files that might remain after a host reboot
+/bin/rm -f /run/tethys_asgi*.sock* >/dev/null 2>&1
+/bin/rm -f /run/supervisord.pid >/dev/null 2>&1
+/bin/rm -f /run/supervisor/supervisor.sock >/dev/null 2>&1
+/bin/rm -f /run/httpd/* >/dev/null 2>&1
+
 # Create Salt Config
 echo "file_client: local" > /etc/salt/minion
 echo "postgres.host: '${TETHYS_DB_HOST}'" >> /etc/salt/minion

--- a/docker/salt/post_app.sls
+++ b/docker/salt/post_app.sls
@@ -34,7 +34,7 @@ Persist_Apache_Config_Post_App:
   file.rename:
     - source: {{ TETHYS_HOME }}/tethys_apache.conf
     - name: {{ TETHYS_PERSIST }}/tethys_apache.conf
-    - unless: /bin/bash -c "[ -f "${TETHYS_PERSIST}/tethys_apache.conf" ];"
+    - force: True
 
 Link_Apache_Config_Post_App:
   file.symlink:

--- a/docker/salt/tethyscore.sls
+++ b/docker/salt/tethyscore.sls
@@ -139,7 +139,6 @@ Generate_Apache_Settings_TethysCore:
         --ip-address $(sed -n '$p'  /etc/hosts | awk '{print $1}')
         --overwrite
         {{ PROXY_SERVER_ADDITIONAL_DIRECTIVES }}
-    - unless: /bin/bash -c "[ -f "{{ TETHYS_PERSIST }}/setup_complete" ];"
 
 Generate_SSL_Certificate_Key_Pair_TethysCore:
   cmd.run:


### PR DESCRIPTION
After a reboot or dockerd restart, the container sometimes received a different internal IP address, causing Apache to fail to bind to the listening port defined in tethys_apache.conf. This change will cause tethys_apache.conf to be rebuilt every time the container starts up.

Also, Apache or Daphne occasionally had trouble with leftover .pid and .sock.lock files in /run/ if their stale Process IDs happened to be taken by a new process after the reboot. This change will remove files from /run/ when the container starts.

CHW-549