### PR TITLE
Set permissions with one chown command

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -92,11 +92,7 @@ salt-call --local --force-color state.apply
 if [[ $test = false ]]; then
   if [[ $skip_perm = false ]]; then
     echo_status "Fixing permissions"
-    find ${STATIC_ROOT} ! -user ${APACHE_USER} -print0 | xargs -0 -I{} chown ${APACHE_USER}: {}
-    find ${WORKSPACE_ROOT} ! -user ${APACHE_USER} -print0 | xargs -0 -I{} chown ${APACHE_USER}: {}
-    find ${TETHYS_PERSIST} ! -user ${APACHE_USER} -print0 | xargs -0 -I{} chown ${APACHE_USER}: {}
-    find ${TETHYSAPP_DIR} ! -user ${APACHE_USER} -print0 | xargs -0 -I{} chown ${APACHE_USER}: {}
-    find ${TETHYS_HOME} ! -user ${APACHE_USER} -print0 | xargs -0 -I{} chown ${APACHE_USER}: {}
+    chown -R ${APACHE_USER} ${STATIC_ROOT} ${WORKSPACE_ROOT} ${TETHYS_PERSIST} ${TETHYSAPP_DIR} ${TETHYS_HOME}
   fi
 
   echo_status "Starting supervisor"


### PR DESCRIPTION
This went from 40 seconds to 0.5 seconds in my one test. 

The previous 5 find commands found every file that was not owned by $APACHE_USER and then started a chown command to fix those individual files. I think "-I{}" caused it to start a new chown command for every individual file. In the end, everything is owned by $APACHE_USER, and running "chown -R" accomplishes that in one process. 