### PR TITLE
Avoid creating superuser account

### DIFF
--- a/docker/salt/tethyscore.sls
+++ b/docker/salt/tethyscore.sls
@@ -199,17 +199,6 @@ Migrate_Database_TethysCore:
     - shell: /bin/bash
     - unless: /bin/bash -c "[ "$SKIP_DB_MIGRATE" = true ];"
 
-Create_Database_Portal_SuperUser_TethysCore:
-  cmd.run:
-    - name: >
-        tethys db createsuperuser
-        {%- if PORTAL_SUPERUSER_NAME and PORTAL_SUPERUSER_PASSWORD %}
-        --pn {{ PORTAL_SUPERUSER_NAME }} --pp {{ PORTAL_SUPERUSER_PASSWORD }}
-        {% endif %}
-        {%- if PORTAL_SUPERUSER_EMAIL %}--pe {{ PORTAL_SUPERUSER_EMAIL }}{% endif %}
-    - shell: /bin/bash
-    - unless: /bin/bash -c "[ -f "{{ TETHYS_PERSIST }}/setup_complete" ] || [ "$SKIP_DB_SETUP" = true ];"
-
 {% if REGISTER_CONTROLLER %}
 Set_Register_Controller_TethysCore:
   cmd.run:


### PR DESCRIPTION
If the admin account is needed, we can create it manually.

I looked into making our setup_complete persistent so createsuperuser wouldn't run repeatedly, but I worry about the settings command not running each time. I also don't want the admin account to be created even on a fresh install.