### PR TITLE
Remove deprecated collectworkspaces command

### DIFF
--- a/docker/salt/post_app.sls
+++ b/docker/salt/post_app.sls
@@ -25,11 +25,6 @@ Collect_Static:
     - name: tethys manage collectstatic --noinput
     - shell: /bin/bash
 
-Collect_Workspaces:
-  cmd.run:
-    - name: tethys manage collectworkspaces
-    - shell: /bin/bash
-
 Persist_Apache_Config_Post_App:
   file.rename:
     - source: {{ TETHYS_HOME }}/tethys_apache.conf


### PR DESCRIPTION
The collectworkspaces command was failing to symlink any directories with Tethys 4.3, and our code is using the new Paths API.

CHW-660